### PR TITLE
Fix docker build in lxc container

### DIFF
--- a/docker/scripts/add-dependencies.sh
+++ b/docker/scripts/add-dependencies.sh
@@ -59,7 +59,7 @@ WSJT_TGZ=${WSJT_DIR}.tgz
 wget https://downloads.sourceforge.net/project/wsjt/${WSJT_DIR}/${WSJT_TGZ}
 tar xfz ${WSJT_TGZ}
 patch -Np0 -d ${WSJT_DIR} < /wsjtx-hamlib.patch
-mv /wsjtx.patch ${WSJT_DIR}
+cp /wsjtx.patch ${WSJT_DIR}
 cmakebuild ${WSJT_DIR}
 rm ${WSJT_TGZ}
 


### PR DESCRIPTION
Docker will use fuse-overlayfs in my lxc container. The problem is that when the file is moved, the mv command returns with error, saying it's the same file and cannot be moved. This is because under the hood, the file is actually the same. Easiest fix is to cp it.