### PR TITLE
add support for extra rows in marker popup table

### DIFF
--- a/htdocs/lib/MapMarkers.js
+++ b/htdocs/lib/MapMarkers.js
@@ -189,9 +189,9 @@ Marker.makeListTitle = function(name) {
 
 // Convert given name/value to an information section item.
 Marker.makeListItem = function(name, value) {
-    return '<div style="border-bottom:1px dotted;white-space:nowrap;">'
+    return '<div style="display:flex;justify-content: space-between;border-bottom:1px dotted;white-space:nowrap;">'
         + '<span>' + name + '&nbsp;&nbsp;&nbsp;&nbsp;</span>'
-        + '<span style="float:right;">' + value + '</span>'
+        + '<span>' + value + '</span>'
         + '</div>';
 };
 
@@ -252,6 +252,12 @@ FeatureMarker.prototype.update = function(update) {
     this.status   = update.location.status;
     this.updated  = update.location.updated;
     this.mmode    = update.location.mmode;
+    var detailsObj = {};
+    var detailsKeys = Object.keys(update.location).filter(function (k) {return k.startsWith('details_')});
+    detailsKeys.forEach(function (d) {
+        detailsObj[d.substring(8)] = update.location[d];
+    });
+    this.detailsData = detailsObj;
 
     // Implementation-dependent function call
     this.setMarkerPosition(update.callsign, update.location.lat, update.location.lon);
@@ -339,6 +345,11 @@ FeatureMarker.prototype.getInfoHTML = function(name, receiverMarker = null) {
             detailsString += Marker.makeListItem('Updated', this.updated);
         }
     }
+
+    var markerExtra = this.detailsData;
+    Object.keys(this.detailsData).sort().forEach(function (k, i) {
+        detailsString += Marker.makeListItem(k.charAt(0).toUpperCase() + k.slice(1), markerExtra[k]);
+    });
 
     if (this.schedule) {
         for (var j=0 ; j<this.schedule.length ; ++j) {

--- a/htdocs/lib/MapMarkers.js
+++ b/htdocs/lib/MapMarkers.js
@@ -252,12 +252,7 @@ FeatureMarker.prototype.update = function(update) {
     this.status   = update.location.status;
     this.updated  = update.location.updated;
     this.mmode    = update.location.mmode;
-    var detailsObj = {};
-    var detailsKeys = Object.keys(update.location).filter(function (k) {return k.startsWith('details_')});
-    detailsKeys.forEach(function (d) {
-        detailsObj[d.substring(8)] = update.location[d];
-    });
-    this.detailsData = detailsObj;
+    this.detailsData = update.location.details;
 
     // Implementation-dependent function call
     this.setMarkerPosition(update.callsign, update.location.lat, update.location.lon);
@@ -346,10 +341,12 @@ FeatureMarker.prototype.getInfoHTML = function(name, receiverMarker = null) {
         }
     }
 
-    var markerExtra = this.detailsData;
-    Object.keys(this.detailsData).sort().forEach(function (k, i) {
-        detailsString += Marker.makeListItem(k.charAt(0).toUpperCase() + k.slice(1), markerExtra[k]);
-    });
+    var markerExtraDetails = this.detailsData;
+    if (typeof markerExtraDetails === 'object') {
+        Object.keys(markerExtraDetails).sort().forEach(function (k, i) {
+            detailsString += Marker.makeListItem(k.charAt(0).toUpperCase() + k.slice(1), markerExtraDetails[k]);
+        });
+    }
 
     if (this.schedule) {
         for (var j=0 ; j<this.schedule.length ; ++j) {


### PR DESCRIPTION
Add extra rows to the popup table for the markers.
If the JSON for the marker has extra keys starting with "details_" string, they will be added to the table.

Example popup:
![image](https://github.com/luarvique/openwebrx/assets/326320/2af5626d-59d6-447c-9fdd-d39d20ef2abb)

Example JSON:
```
  "LZ0VNA": {         
    "freq": "438300000", 
    "mode": "Reps-BG",         
    "rx": 438.3,            
    "details_loc": "Варна",
    "details_keeper": "LZ2VVP",
    "mmode": "fm",          
    "lon": 27.9286,           
    "symbol": "&#9094;",     
    "tx": 430.7,    
    "details_mode": "analog, fusion",
    "updated": "2022-12-01",
    "altitude": 169,        
    "id": "R-LZ0VNA",  
    "details_qth": "KN33XD29", 
    "color": "#60274E",     
    "details_zello": "LZ0VNA-KNN (pass: Userlz0vna)",                                                                                                           
    "type": "feature",                                                          
    "lat": 43.1621,            
    "details_tone": 79.7     
  },                        
```


Reworked for JSON:
```
"LZ0VNA": {
  "freq": "438300000",
  "mode": "Reps-BG",
  "rx": 438.3,
  "details": {
    "loc": "Варна",
    "keeper": "LZ2VVP",
    "mode": "analog, fusion",
    "zello": "LZ0VNA-KNN (pass: Userlz0vna)",
    "tone": 79.7,
    "qth": "KN33XD29"
  },
  "mmode": "fm",
  "lon": 27.9286,
  "symbol": "&#9094;",
  "tx": 430.7,
  "updated": "2022-12-01",
  "altitude": 169,
  "id": "R-LZ0VNA",
  "color": "#60274E",
  "type": "feature",
  "lat": 43.1621
}
```