### PR TITLE
Fix docker tools and drivers for AMD cpu.

### DIFF
--- a/docker/deb_based/install-owrxp-extra.sh
+++ b/docker/deb_based/install-owrxp-extra.sh
@@ -19,6 +19,7 @@ function cmakebuild() {
   rm -rf $1
 }
 
+export MARCH=native
 case `uname -m` in
     arm*)
         SDRPLAY_BINARY=SDRplay_RSP_API-ARM32-3.07.2.run
@@ -28,6 +29,7 @@ case `uname -m` in
         ;;
     x86_64*)
         SDRPLAY_BINARY=SDRplay_RSP_API-Linux-3.07.1.run
+        export MARCH=x86-64
         ;;
 esac
 
@@ -52,6 +54,7 @@ git clone https://github.com/Microtelecom/libperseus-sdr.git
 cd libperseus-sdr
 # latest from master as of 2020-09-04
 git checkout c2c95daeaa08bf0daed0e8ada970ab17cc264e1b
+sed -i 's/-march=native/-march='${MARCH}'/g' configure.ac
 ./bootstrap.sh
 ./configure
 make
@@ -108,6 +111,7 @@ git clone https://github.com/szpajder/libacars.git
 cmakebuild libacars v2.1.4
 
 git clone https://github.com/TLeconte/acarsdec.git
+sed -i 's/-march=native/-march='${MARCH}'/g' acarsdec/CMakeLists.txt
 cmakebuild acarsdec
 
 echo "+ Install HFDL..."

--- a/docker/scripts/add-dependencies.sh
+++ b/docker/scripts/add-dependencies.sh
@@ -26,6 +26,7 @@ apt-get update
 apt-get -y install auto-apt-proxy
 apt-get -y install --no-install-recommends $STATIC_PACKAGES $BUILD_PACKAGES
 
+export MARCH=x86-64
 case `uname -m` in
     arm*)
         PLATFORM=armhf
@@ -35,6 +36,7 @@ case `uname -m` in
         ;;
     x86_64*)
         PLATFORM=amd64
+        export MARCH=x86-64
         ;;
 esac
 
@@ -121,6 +123,7 @@ git clone https://github.com/szpajder/libacars.git
 cmakebuild libacars v2.1.4
 
 git clone https://github.com/TLeconte/acarsdec.git
+sed -i 's/-march=native/-march='${MARCH}'/g' acarsdec/CMakeLists.txt
 cmakebuild acarsdec
 
 git clone https://github.com/szpajder/dumphfdl.git

--- a/docker/scripts/install-100-dependencies-perseus.sh
+++ b/docker/scripts/install-100-dependencies-perseus.sh
@@ -6,6 +6,15 @@ cd /tmp
 STATIC_PACKAGES="libusb-1.0-0 libudev1"
 BUILD_PACKAGES="git make gcc autoconf automake libtool libusb-1.0-0-dev xxd"
 
+export MARCH=native
+case `uname -m` in
+    x86_64*)
+        export MARCH=x86-64
+        ;;
+esac
+
+
+
 if [[ -z ${1:-} ]]; then
   apt-get update
   apt-get -y install --no-install-recommends $STATIC_PACKAGES $BUILD_PACKAGES
@@ -14,6 +23,7 @@ if [[ -z ${1:-} ]]; then
   cd libperseus-sdr
   # latest from master as of 2020-09-04
   git checkout c2c95daeaa08bf0daed0e8ada970ab17cc264e1b
+  sed -i 's/-march=native/-march='${MARCH}'/g' configure.ac
   ./bootstrap.sh
   ./configure
   make


### PR DESCRIPTION
The build is prepared on Intel CPU.
acarsdec and perseus driver are using -march=native, which results in some wrong opcodes for AMD cpus.
Changing to -march=x86-64 will fix the problem.