### PR TITLE
fix Leaflet maps when we have custom markers in /etc/openwebrx/markers.d

### DIFF
--- a/htdocs/map-leaflet.js
+++ b/htdocs/map-leaflet.js
@@ -440,7 +440,7 @@ MapManager.prototype.processUpdates = function(updates) {
                             if (!update.location.color)  update.location.color  = self.mman.getColor(update.mode);
                             break;
                         default:
-                            marker = new LMarker();
+                            marker = new LAprsMarker();
                             break;
                     }
 


### PR DESCRIPTION
The "default" (unknown) marker is created with LMarker class, which lacks many methods. It is a base class.
With this commit, the "default" marker will be APRS marker (LAprsMarker class), which will allow the markers to be created.