### PR TITLE
Add EAS/SAME decoder capability

### DIFF
--- a/bands.json
+++ b/bands.json
@@ -450,5 +450,14 @@
     "frequencies": {
       "ais": [161975000, 162025000]
     }
+  },
+  {
+    "name": "NOAA Weather Radio",
+    "lower_bound": 162390000,
+    "upper_bound": 162560000,
+    "tags": ["service"],
+    "frequencies": {
+      "eassame": [162400000, 162425000, 162450000, 162475000, 162500000, 162525000, 162550000]
+    }
   }
 ]

--- a/csdr/chain/toolbox.py
+++ b/csdr/chain/toolbox.py
@@ -2,7 +2,7 @@ from csdr.chain.demodulator import ServiceDemodulator, DialFrequencyReceiver
 from csdr.module.toolbox import Rtl433Module, MultimonModule, DumpHfdlModule, DumpVdl2Module, Dump1090Module, AcarsDecModule, RedseaModule, SatDumpModule
 from pycsdr.modules import FmDemod, AudioResampler, Convert, Agc, Squelch
 from pycsdr.types import Format
-from owrx.toolbox import TextParser, PageParser, SelCallParser, IsmParser, RdsParser
+from owrx.toolbox import TextParser, PageParser, SelCallParser, EasSameParser, IsmParser, RdsParser
 from owrx.aircraft import HfdlParser, Vdl2Parser, AdsbParser, AcarsParser
 
 from datetime import datetime
@@ -88,6 +88,15 @@ class SelCallDemodulator(MultimonDemodulator):
         super().__init__(
             ["DTMF", "EEA", "EIA", "CCIR"],
             SelCallParser(service=service),
+            withSquelch = True
+        )
+
+
+class EasSameDemodulator(MultimonDemodulator):
+    def __init__(self, service: bool = False):
+        super().__init__(
+            ["EAS"],
+            EasSameParser(service=service),
             withSquelch = True
         )
 

--- a/owrx/dsp.py
+++ b/owrx/dsp.py
@@ -677,6 +677,9 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
         elif mod == "selcall":
             from csdr.chain.toolbox import SelCallDemodulator
             return SelCallDemodulator()
+        elif mod == "eassame":
+            from csdr.chain.toolbox import EasSameDemodulator
+            return EasSameDemodulator()
         elif mod == "zvei":
             from csdr.chain.toolbox import ZveiDemodulator
             return ZveiDemodulator()

--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -92,6 +92,7 @@ class FeatureDetector(object):
         "acars": ["acarsdec"],
         "page": ["multimon"],
         "selcall": ["multimon"],
+        "eas_same": ["multimon", "dsame3_simple"],
         "wxsat": ["satdump"],
         "png": ["imagemagick"],
         "rds": ["redsea"],
@@ -736,6 +737,12 @@ class FeatureDetector(object):
         distributions.
         """
         return self.command_is_runnable("multimon-ng --help")
+
+    def has_dsame3_simple(self):
+        """
+        dsame3_simple is used to decode EAS SAME messages to readable text.
+        """
+        return self.command_is_runnable("dsame3_simple --help")
 
     def has_satdump(self):
         """

--- a/owrx/modes.py
+++ b/owrx/modes.py
@@ -221,7 +221,8 @@ class Modes(object):
             "EAS SAME",
             underlying=["nfm"],
             requirements=["eas_same"],
-            squelch=True
+            service=True,
+            squelch=False
         ),
         DigitalMode(
             "zvei",

--- a/owrx/modes.py
+++ b/owrx/modes.py
@@ -217,6 +217,13 @@ class Modes(object):
             squelch=True
         ),
         DigitalMode(
+            "eassame",
+            "EAS SAME",
+            underlying=["nfm"],
+            requirements=["eas_same"],
+            squelch=True
+        ),
+        DigitalMode(
             "zvei",
             "Zvei",
             underlying=["nfm"],

--- a/owrx/service/__init__.py
+++ b/owrx/service/__init__.py
@@ -335,6 +335,9 @@ class ServiceHandler(SdrSourceEventClient):
         elif mod == "page":
             from csdr.chain.toolbox import PageDemodulator
             return PageDemodulator(service=True)
+        elif mod == "eassame":
+            from csdr.chain.toolbox import EasSameDemodulator
+            return EasSameDemodulator(service=True)
         elif mod == "ism":
             from csdr.chain.toolbox import IsmDemodulator
             return IsmDemodulator(service=True)

--- a/owrx/toolbox.py
+++ b/owrx/toolbox.py
@@ -399,6 +399,8 @@ class EasSameParser(TextParser):
                     "message":   d['msg'],
                     "raw":       s
                 }
+                spot['start_time'] = spot['start_time'].astimezone(timezone.utc).isoformat()
+                spot['end_time'] = spot['end_time'].astimezone(timezone.utc).isoformat()
                 del spot['msg']
                 ReportingEngine.getSharedInstance().spot(spot)
 

--- a/owrx/toolbox.py
+++ b/owrx/toolbox.py
@@ -375,7 +375,7 @@ class EasSameParser(TextParser):
     def __init__(self, service: bool = False):
         self.reSplit = re.compile(r"(EAS: \S+)")
         # Construct parent object
-        super().__init__(filePrefix="EAS_SAME", service=service)
+        super().__init__(filePrefix="EASSAME", service=service)
 
     def parse(self, msg: bytes):
         # Parse EAS SAME messages
@@ -403,8 +403,5 @@ class EasSameParser(TextParser):
                 spot['end_time'] = spot['end_time'].astimezone(timezone.utc).isoformat()
                 del spot['msg']
                 ReportingEngine.getSharedInstance().spot(spot)
-
-        if self.service:
-            return None
 
         return '\n'.join(out)

--- a/owrx/toolbox.py
+++ b/owrx/toolbox.py
@@ -370,3 +370,31 @@ class SelCallParser(TextParser):
                 dec = None
         # Done
         return out
+
+class EasSameParser(TextParser):
+    def __init__(self, service: bool = False):
+        self.reSplit = re.compile(r"(EAS: \S+)")
+        self.reMatch = re.compile(r"EAS")
+        self.mode = ""
+        # Construct parent object
+        super().__init__(filePrefix="EAS_SAME", service=service)
+
+    def parse(self, msg: bytes):
+        # Do not parse in service mode
+        if self.service:
+            return None
+        # Parse EAS SAME messages
+        from dsame3_simple.dsame import same_decode_string
+        msg = msg.decode('utf-8', 'replace')
+        out = []
+
+        r = self.reSplit.split(msg)
+        for s in r:
+            if not self.reMatch.match(s):
+                continue
+            dec = same_decode_string(s)
+            if not dec:
+                continue
+            out += [s, '\n'.join(dec), '']
+        # Done
+        return '\n'.join(out)

--- a/owrx/toolbox.py
+++ b/owrx/toolbox.py
@@ -391,7 +391,7 @@ class EasSameParser(TextParser):
             if not dec:
                 continue
             for d in dec:
-                out += [s, '\n'.join(d['msg']), '']
+                out += [s, d['msg'], '']
                 spot = {
                     **d,
                     "mode":      "EAS_SAME",

--- a/owrx/toolbox.py
+++ b/owrx/toolbox.py
@@ -393,11 +393,12 @@ class EasSameParser(TextParser):
             for d in dec:
                 out += [s, d['msg'], '']
                 spot = {
-                    **d,
                     "mode":      "EAS_SAME",
-                    "timestamp": self.getUtcTime(),
+                    "freq":      self.frequency,
+                    "timestamp": round(datetime.now().timestamp() * 1000),
                     "message":   d['msg'],
-                    "raw":       s
+                    "raw":       s,
+                    **d
                 }
                 spot['start_time'] = spot['start_time'].astimezone(timezone.utc).isoformat()
                 spot['end_time'] = spot['end_time'].astimezone(timezone.utc).isoformat()


### PR DESCRIPTION
This adds an EAS/SAME decoder that captures the raw alert using `multimon-ng` and converts the raw alert to readable text using `dsame3_simple`.

Tested against both synthetic signals and a couple of over-the-air signals, both in live and background mode.  Not a ton of test history, given how often rare the signals are, but it seems to work.

Can be used as a live decoder with the text shown on the decode window, or as a background service to send to MQTT / log to file.

Requirements to activate feature:
`multimon-ng` (already in use for several decoders)
python package `dsame3_simple`