### PR TITLE
Change volume slider to a logarithmic scale

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -225,7 +225,7 @@
                                 <svg class="unmuted" viewBox="0 0 80 80"><use xlink:href="static/gfx/svg-defs.svg#speaker"></use></svg>
                                 <svg class="muted" viewBox="0 0 80 80"><use xlink:href="static/gfx/svg-defs.svg#speaker-muted"></use></svg>
                             </div>
-                            <input title="Volume" id="openwebrx-panel-volume" class="openwebrx-panel-slider" type="range" min="0" max="150" value="50" step="1" onchange="UI.setVolume(this.value);" oninput="UI.setVolume(this.value);">
+                            <input title="Volume" id="openwebrx-panel-volume" class="openwebrx-panel-slider" type="range" min="0" max="150" value="100" step="1" onchange="UI.setVolume(this.value);" oninput="UI.setVolume(this.value);">
                             <div title="Tuning step" class="openwebrx-button openwebrx-slider-button" onclick="tuning_step_reset();">
                                 <svg viewBox="0 0 80 80"><use xlink:href="static/gfx/svg-defs.svg#tuning-step"></use></svg>
                             </div>

--- a/htdocs/lib/UI.js
+++ b/htdocs/lib/UI.js
@@ -75,7 +75,10 @@ UI.setVolume = function(x) {
         this.volume = x;
         LS.save('volume', x);
         $('#openwebrx-panel-volume').val(x)
-        if (audioEngine) audioEngine.setVolume(x / 100);
+        //Map 0-150 to -60 to 0db gain
+        xdb = (x / 2.5)  - 60;
+        gain = Math.pow(10, xdb / 20);
+        if (audioEngine) audioEngine.setVolume(gain);
     }
 };
 

--- a/htdocs/lib/UI.js
+++ b/htdocs/lib/UI.js
@@ -78,6 +78,9 @@ UI.setVolume = function(x) {
         //Map 0-150 to -60 to 0db gain
         xdb = (x / 2.5)  - 60;
         gain = Math.pow(10, xdb / 20);
+        if (x == 0) {
+            gain = 0;
+        }
         if (audioEngine) audioEngine.setVolume(gain);
     }
 };


### PR DESCRIPTION
Human hearing works on a logarithmic scale, and in the interest of not breaking the saved user settings I mapped the existing 0-150 scale to -60 to 0db gain.

This could probably be done differently and I'm happy to change things, but I'd like to be able to use more than the bottom 10% of the volume bar, 10% volume being -20db gain currently.