### PR TITLE
Port SoapyMiri driver from OpenWebRX_E

### DIFF
--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -57,6 +57,7 @@ class FeatureDetector(object):
         "rtl_sdr_soapy": ["soapy_connector", "soapy_rtl_sdr"],
         "rtl_tcp": ["rtl_tcp_connector"],
         "sdrplay": ["soapy_connector", "soapy_sdrplay"],
+        "soapyMiri": ["soapy_connector", "soapy_soapyMiri"],
         "hackrf": ["soapy_connector", "soapy_hackrf"],
         "perseussdr": ["perseustest", "nmux"],
         "airspy": ["soapy_connector", "soapy_airspy"],
@@ -340,6 +341,14 @@ class FeatureDetector(object):
         from the manufacturer.
         """
         return self._has_soapy_driver("sdrplay")
+
+    def has_soapy_soapyMiri(self):
+        """
+        The [SoapySDR module for Miric](https://github.com/ericek111/SoapyMiri)
+        devices is required for interfacing with Miric-based hardware (MSi2500 etc).
+        You will also need to install the [libmirisdr-5](https://github.com/ericek111/libmirisdr-5) library.
+        """
+        return self._has_soapy_driver("soapyMiri")
 
     def has_soapy_airspy(self):
         """

--- a/owrx/source/soapyMiri.py
+++ b/owrx/source/soapyMiri.py
@@ -1,0 +1,98 @@
+# eroyee; experimental module for soapyMiri driver that should run Mirics-based hardware.
+#
+# Library / driver is from Erik here : https://github.com/ericek111/SoapyMiri, and
+# Edouard here: https://github.com/f4exb/libmirisdr-4
+#
+# This is quite alpha, I've tested it with just one device which seems to work,
+# but there may be some spurious signals, and in some cases it won't receive
+# dead on the centre frequency. This should be addressable by setting an offset.
+# 
+# Help to improve this is welcome, and there may be other settings to implement
+# in time, just not yet.
+#
+# Sampling rate should be set at specified values such as 2, 5, 8 MHz, other rates 
+# can give errors.
+#
+# If present you will need to blacklist the msi2500 device drivers. 
+# See : https://www.radiosrs.net/msi2500_driver_conflicts.html
+
+from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
+from owrx.form.input import Input, CheckboxInput, DropdownInput, DropdownEnum
+from owrx.form.input.device import BiasTeeInput
+from typing import List
+
+
+class SoapymiriSource(SoapyConnectorSource):
+    def getSoapySettingsMappings(self):
+        mappings = super().getSoapySettingsMappings()
+        mappings.update(
+            {
+                "bias_tee": "biasT_ctrl",
+                "offset_tune": "offset_tune",
+                "bufflen": "bufflen",
+                "buffers": "buffers",
+                "asyncbuffers": "asyncBuffs",
+            }
+        )
+        return mappings
+
+    def getDriver(self):
+        return "soapyMiri"
+
+class BuffLenOptions(DropdownEnum):
+    BUFFLEN_15872 = "15872"
+    BUFFLEN_36864 = "36864"
+    BUFFLEN_73728 = "73728"
+
+    def __str__(self):
+        return self.value
+
+class BuffersOptions(DropdownEnum):
+    BUFFERS_8 = "8"
+    BUFFERS_15 = "15"
+    BUFFERS_24 = "24"
+
+    def __str__(self):
+        return self.value
+
+class AsyncBuffsOptions(DropdownEnum):
+    ASYNCBUFF_0 = "0"
+    ASYNCBUFF_2 = "2"
+    ASYNCBUFF_4 = "4"
+
+    def __str__(self):
+        return self.value
+
+class SoapymiriDeviceDescription(SoapyConnectorDeviceDescription):
+    def getName(self):
+        return "Miric-based device (via SoapySDR)"
+
+    def getInputs(self) -> List[Input]:
+        return super().getInputs() + [
+            BiasTeeInput(),
+            CheckboxInput(
+                "offset_tune",
+                "Offset Tuning Mode, default=off",
+            ),
+            DropdownInput(
+                "bufflen",
+                "Bufferlength in 512byte multiples, default=36864",
+                BuffLenOptions,
+            ),
+            DropdownInput(
+                "buffers",
+                "Buffers in ring, default=15",
+                BuffersOptions,
+            ),
+            DropdownInput(
+                "asyncbuffers",
+                "Async USB buffers, default=0",
+                AsyncBuffsOptions,
+            ),
+        ]
+
+    def getDeviceOptionalKeys(self):
+        return super().getDeviceOptionalKeys() + ["bias_tee", "offset_tune", "bufflen", "buffers", "asyncbuffers"]
+
+    def getProfileOptionalKeys(self):
+        return super().getProfileOptionalKeys() + ["bias_tee", "offset_tune", "bufflen" "buffers", "asyncbuffers"]


### PR DESCRIPTION
This one has a bit of history. This code comes directly from https://github.com/eroyee/openwebrx_E, and is an open source replacement driver for SDRPlay devices, it does not require their API/root service running in the background.

Jketterl has rejected supporting this driver in the past: https://groups.io/g/openwebrx/topic/92350709#msg5618 - this thread is worth reading before even considering a merge.

I have personally run this code with OpenWebRX+ for about a year - the SoapyMiri driver is much more CPU friendly on a Pi4, but I believe this is because the official SDRPlay driver automatically selects the highest sample rate and decimates down to its target which choked the pi's even on low sample rate settings, but I have not tried the official driver for a while and don't know if this has changed.

The performance is worse than the official driver as it doesn't oversample and decimate down, but that being said my SDR does regularly beat my real Icom 7300 radio due to the antenna being further away from the house and the antenna having a feedpoint preamp.