### PR TITLE
Restore SoapyMiri driver

### DIFF
--- a/owrx/source/mirics.py
+++ b/owrx/source/mirics.py
@@ -37,7 +37,7 @@ class MiricsSource(SoapyConnectorSource):
         return mappings
 
     def getDriver(self):
-        return "mirics"
+        return "soapyMiri"
 
 class BuffLenOptions(DropdownEnum):
     BUFFLEN_15872 = "15872"


### PR DESCRIPTION
The 'mirics' driver is ancient, broken, and should not be used. The last commit to that driver was 9 years ago: https://github.com/pothosware/SoapyOsmo/blob/master/gr-osmosdr/lib/miri/miri_source_c.cc

If you are on debian, you need to uninstall 'soapysdr-module-mirisdr', this is the broken driver.

The correct driver is named 'soapyMiri' located here:
https://github.com/ericek111/SoapyMiri.git
which requires the library here:
https://github.com/ericek111/libmirisdr-5.

I'd prefer to see this merge request rejected and revert 7b4d06dd7f4ae717a0cc20f7d90f01be8312af9f to make it distinct from the mirics driver, but it's up to you.