### PR TITLE
State max file size for receiver panorama and avatar images

### DIFF
--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -72,13 +72,13 @@ class GeneralSettingsController(SettingsFormController):
                 AvatarInput(
                     "receiver_avatar",
                     "Receiver Avatar",
-                    infotext="Max file size 256KB. For performance reasons, images are cached. "
+                    infotext="Maximum file size is 256kB. For performance reasons, images are cached. "
                     + "It can take a few hours until they appear on the site.",
                 ),
                 TopPhotoInput(
                     "receiver_top_photo",
                     "Receiver Panorama",
-                    infotext="Max file size 2MB. For performance reasons, images are cached. "
+                    infotext="Maximum file size is 2MB. For performance reasons, images are cached. "
                     + "It can take a few hours until they appear on the site.",
                 ),
             ),

--- a/owrx/controllers/settings/general.py
+++ b/owrx/controllers/settings/general.py
@@ -72,13 +72,13 @@ class GeneralSettingsController(SettingsFormController):
                 AvatarInput(
                     "receiver_avatar",
                     "Receiver Avatar",
-                    infotext="For performance reasons, images are cached. "
+                    infotext="Max file size 256KB. For performance reasons, images are cached. "
                     + "It can take a few hours until they appear on the site.",
                 ),
                 TopPhotoInput(
                     "receiver_top_photo",
                     "Receiver Panorama",
-                    infotext="For performance reasons, images are cached. "
+                    infotext="Max file size 2MB. For performance reasons, images are cached. "
                     + "It can take a few hours until they appear on the site.",
                 ),
             ),


### PR DESCRIPTION
Currently, if you try to change the receiver avatar or panorama images to an image that exceeds the max file size, you get the error "Maximum file size exceeded". However, the error does not state what the maximum file size is, so you either have to keep trying smaller and smaller images until one is accepted, or you dig into the HTML to find it.

The only change in this pull request is to add "Max file size 2KB." and "Max file size 2MB." to the avatar and panorama infotips, respectively.