### PR TITLE
Add bias-tee support for rtl_tcp source

### DIFF
--- a/owrx/source/rtl_tcp.py
+++ b/owrx/source/rtl_tcp.py
@@ -1,7 +1,7 @@
 from owrx.source.connector import ConnectorSource, ConnectorDeviceDescription
 from owrx.command import Flag, Option, Argument
 from owrx.form.input import Input
-from owrx.form.input.device import RemoteInput, DirectSamplingInput
+from owrx.form.input.device import RemoteInput, DirectSamplingInput, BiasTeeInput
 from owrx.form.input.validator import Range
 from typing import List
 
@@ -27,16 +27,16 @@ class RtlTcpDeviceDescription(ConnectorDeviceDescription):
         return "RTL-SDR device (via rtl_tcp)"
 
     def getInputs(self) -> List[Input]:
-        return super().getInputs() + [RemoteInput(), DirectSamplingInput()]
+        return super().getInputs() + [RemoteInput(), DirectSamplingInput(), BiasTeeInput()]
 
     def getDeviceMandatoryKeys(self):
         return super().getDeviceMandatoryKeys() + ["remote"]
 
     def getDeviceOptionalKeys(self):
-        return super().getDeviceOptionalKeys() + ["direct_sampling"]
+        return super().getDeviceOptionalKeys() + ["direct_sampling", "bias_tee"]
 
     def getProfileOptionalKeys(self):
-        return super().getProfileOptionalKeys() + ["direct_sampling"]
+        return super().getProfileOptionalKeys() + ["direct_sampling", "bias_tee"]
 
     def getSampleRateRanges(self) -> List[Range]:
         return [Range(250000, 3200000)]


### PR DESCRIPTION
A small change so you can use a bias-tee with rtl_tcp sources.