### PR TITLE
Added newer Yaesu radios to APRS

### DIFF
--- a/owrx/aprs/__init__.py
+++ b/owrx/aprs/__init__.py
@@ -576,14 +576,18 @@ class MicEParser(object):
             if len(comment) > 2 and (comment[0] == "`" or comment[0] == "'"):
                 if comment[-2] == "_":
                     devices = {
-                        "b": "VX-8",
+                        ")": "FTM-100D",
+                        "2": "FTM-200D",
+                        "1": "FTM-300D",
                         '"': "FTM-350",
+                        "4": "FTM-500D",
+                        "%": "FTM-400DR",
+                        "b": "VX-8",
                         "#": "VX-8G",
                         "$": "FT1D",
-                        "%": "FTM-400DR",
-                        ")": "FTM-100D",
                         "(": "FT2D",
                         "0": "FT3D",
+                        "1": "FT5D",
                     }
                     return comment[1:-2], {"manufacturer": "Yaesu", "device": devices.get(comment[-1], "Unknown")}
                 if comment[-2:] == " X":


### PR DESCRIPTION
Added the FTM-200, 300, 500, VX-8, FT5D to the APRS Devices list.