### PR TITLE
Add descriptions for gain stages in profile settings

### DIFF
--- a/owrx/form/input/device.py
+++ b/owrx/form/input/device.py
@@ -5,10 +5,14 @@ from owrx.soapy import SoapySettings
 
 
 class GainInput(Input):
-    def __init__(self, id, label, has_agc, gain_stages=None):
+    def __init__(self, id, label, has_agc, gain_stages=None, gain_stage_descriptions=None):
         super().__init__(id, label)
         self.has_agc = has_agc
         self.gain_stages = gain_stages
+        self.gain_stage_descriptions = gain_stage_descriptions
+
+        if self.gain_stages is not None and self.gain_stage_descriptions is None:
+            self.gain_stage_descriptions = {s: s for s in self.gain_stages}
 
     def render_input(self, value, errors):
         try:
@@ -93,13 +97,14 @@ class GainInput(Input):
             inputs="".join(
                 """
                     <div class="row">
-                        <label class="col-form-label col-form-label-sm col-3">{stage}</label>
+                        <label class="col-form-label col-form-label-sm col-3">{stagedesc}</label>
                         <input type="number" id="{id}-{stage}" name="{id}-{stage}" value="{value}"
                         class="col-9 {classes}" placeholder="{stage}" step="any" {disabled}>
                     </div>
                 """.format(
                     id=self.id,
                     stage=stage,
+                    stagedesc=self.gain_stage_descriptions[stage],
                     value=value_dict[stage] if stage in value_dict else "",
                     classes=self.input_classes(errors),
                     disabled="disabled" if self.disabled else "",
@@ -214,7 +219,7 @@ class SchedulerInput(Input):
         return """
             <select class="{extra_classes} {classes}" id="{id}" name="{id}" {disabled}>
                 {options}
-            </select> 
+            </select>
         """.format(
             id="{}-{}".format(self.id, stage),
             classes=self.input_classes(errors),

--- a/owrx/source/airspy.py
+++ b/owrx/source/airspy.py
@@ -50,6 +50,13 @@ class AirspyDeviceDescription(SoapyConnectorDeviceDescription):
     def getGainStages(self):
         return ["LNA", "MIX", "VGA"]
 
+    def getGainStageDescriptions(self):
+        return {
+            "LNA": "LNA Gain",
+            "MIX": "Mixer Gain",
+            "VGA": "IF Gain",
+        }
+
     def getSampleRateRanges(self) -> List[Range]:
         # Airspy R2 does 2.5 or 10 MS/s
         # Airspy mini does 3 or 6 MS/s

--- a/owrx/source/hackrf.py
+++ b/owrx/source/hackrf.py
@@ -34,7 +34,14 @@ class HackrfDeviceDescription(SoapyConnectorDeviceDescription):
         return super().getProfileOptionalKeys() + ["bias_tee"]
 
     def getGainStages(self):
-        return ["LNA", "AMP", "VGA"]
+        return ["AMP","LNA","VGA"]
+
+    def getGainStageDescriptions(self):
+        return {
+            "AMP": "R.F. AMP (0 or 11db)",
+            "LNA": "I.F. LNA (0-40db/8db)",
+            "VGA": "B.B. VGA (0-62db/2db)"
+        }
 
     def getSampleRateRanges(self) -> List[Range]:
         return [Range(500000, 28000000)]

--- a/owrx/source/soapy.py
+++ b/owrx/source/soapy.py
@@ -103,6 +103,7 @@ class SoapyConnectorDeviceDescription(ConnectorDeviceDescription):
                 "Device Gain",
                 gain_stages=self.getGainStages(),
                 has_agc=self.hasAgc(),
+                gain_stage_descriptions=self.getGainStageDescriptions(),
             ),
             TextInput("antenna", "Antenna"),
         ]
@@ -130,4 +131,7 @@ class SoapyConnectorDeviceDescription(ConnectorDeviceDescription):
         return super().getProfileOptionalKeys() + ["antenna"]
 
     def getGainStages(self):
+        return None
+
+    def getGainStageDescriptions(self):
         return None


### PR DESCRIPTION
Add descriptions for gain stages in profile settings, primarily for HackRF One.

I got so fed up of having to lookup the valid values of each gain stage and what part of the RF chain they applied to so I decided to make the field labels for the manual gain settings able to be more descriptive.

![image](https://github.com/user-attachments/assets/4d8145ce-0424-49e9-b9bb-a5bb58a2042e)
