### PR TITLE
Add a config option for NFM default devation

### DIFF
--- a/owrx/config/defaults.py
+++ b/owrx/config/defaults.py
@@ -18,6 +18,7 @@ defaultConfig = PropertyLayer(
     fft_compression="adpcm",
     wfm_deemphasis_tau=50e-6,
     wfm_rds_rbds=False,
+    nfm_default_deviation=8000,
     digimodes_fft_size=2048,
     digital_voice_dmr_id_lookup=True,
     digital_voice_nxdn_id_lookup=True,

--- a/owrx/controllers/settings/decoding.py
+++ b/owrx/controllers/settings/decoding.py
@@ -43,6 +43,13 @@ class DecodingSettingsController(SettingsFormController):
                     "wfm_rds_rbds",
                     "Decode USA-specific RBDS information from WFM broadcasts",
                 ),
+                NumberInput(
+                    "nfm_default_deviation",
+                    "NFM default deviation",
+                    infotext="Default demodulation bandwidth for NFM",
+                    validator=RangeValidator(2000, 25000),
+                    append="Hz"
+                ),
                 CheckboxInput(
                     "cw_showcw",
                     "Show CW codes (dits / dahs) when decoding CW",

--- a/owrx/modes.py
+++ b/owrx/modes.py
@@ -1,3 +1,4 @@
+from owrx.config import Config
 from owrx.feature import FeatureDetector
 from owrx.audio import ProfileSource
 from functools import reduce
@@ -359,6 +360,8 @@ class Modes(object):
 
     @staticmethod
     def getModes():
+        nfm_deviation = Config.get()["nfm_default_deviation"] /2 if "nfm_default_deviation" in Config.get() else 4000
+        Modes.mappings[0] = AnalogMode("nfm", "FM", bandpass=Bandpass(-int(nfm_deviation), int(nfm_deviation)))
         return Modes.mappings
 
     @staticmethod


### PR DESCRIPTION
For listening to repeaters I tend to use a narrower bandwidth than the default 8khz for nfm ('FM' button). I've added an option in the settings to choose what the default deviation is used for nfm. It has a range of 2000 to 25000 Hz and defaults to 8000 Hz.

![image](https://github.com/user-attachments/assets/0cba2900-b5ef-4aa9-9be9-fe100c8fabab)
