### PR TITLE
Rig information

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -378,6 +378,8 @@ Note: if you experience audio underruns while CPU usage is 100%, you can:
 #pskreporter_callsign = "N0CALL"
 # optional antenna information, uncomment to enable
 #pskreporter_antenna_information = "Dipole"
+# optional rig information, uncomment to enable
+#pskreporter_rig_information = "Homebrew"
 
 # === WSPRNet reporting settings
 # enable this if you want to upload WSPR spots to wsprnet.ort

--- a/owrx/config/defaults.py
+++ b/owrx/config/defaults.py
@@ -400,6 +400,7 @@ defaultConfig = PropertyLayer(
     pskreporter_enabled=False,
     pskreporter_callsign="N0CALL",
     # pskreporter_antenna_information=None,
+    # pskreporter_rig_information=None,
     wsprnet_enabled=False,
     wsprnet_callsign="N0CALL",
     mqtt_enabled=False,

--- a/owrx/controllers/settings/reporting.py
+++ b/owrx/controllers/settings/reporting.py
@@ -78,6 +78,12 @@ class ReportingController(SettingsFormController):
                     infotext="Antenna description to be sent along with spots to pskreporter",
                     converter=OptionalConverter(),
                 ),
+                TextInput(
+                    "pskreporter_rig_information",
+                    "Rig information",
+                    infotext="Rig information also sent to pskreporter",
+                    converter=OptionalConverter(),
+                ),
             ),
             Section(
                 "WSPRnet settings",

--- a/owrx/reporting/pskreporter.py
+++ b/owrx/reporting/pskreporter.py
@@ -166,10 +166,8 @@ class Uploader(object):
         with_antenna = "pskreporter_antenna_information" in pm and pm["pskreporter_antenna_information"] is not None
         with_rig = "pskreporter_rig_information" in pm and pm["pskreporter_rig_information"] is not None
         num_fields = 3
-        if with_antenna:
-            num_fields += 1
-        if with_rig:
-            num_fields += 1
+        num_fields += 1 if with_antenna
+        num_fields += 1 if with_rig
         length = 12 + num_fields * 8
         return bytes(
             # id

--- a/owrx/reporting/pskreporter.py
+++ b/owrx/reporting/pskreporter.py
@@ -164,7 +164,12 @@ class Uploader(object):
     def getReceiverInformationHeader(self):
         pm = Config.get()
         with_antenna = "pskreporter_antenna_information" in pm and pm["pskreporter_antenna_information"] is not None
-        num_fields = 4 if with_antenna else 3
+        with_rig = "pskreporter_rig_information" in pm and pm["pskreporter_rig_information"] is not None
+        num_fields = 3
+        if with_antenna:
+            num_fields += 1
+        if with_rig:
+            num_fields += 1
         length = 12 + num_fields * 8
         return bytes(
             # id
@@ -184,6 +189,8 @@ class Uploader(object):
             + [0x80, 0x08, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F]
             # antennaInformation
             + ([0x80, 0x09, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F] if with_antenna else [])
+            # rigInformation
+            + ([0x80, 0x0D, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F] if with_rig else [])
             # padding
             + [0x00, 0x00]
         )
@@ -200,6 +207,8 @@ class Uploader(object):
         ]
         if "pskreporter_antenna_information" in pm and pm["pskreporter_antenna_information"] is not None:
             bodyFields += [pm["pskreporter_antenna_information"]]
+        if "pskreporter_rig_information" in pm and pm["pskreporter_rig_information"] is not None:
+            bodyFields += [pm["pskreporter_rig_information"]]
         body = [b for s in bodyFields for b in self.encodeString(s)]
         body = self.pad(body, 4)
         body = bytes(Uploader.receieverDelimiter + list((len(body) + 4).to_bytes(2, "big")) + body)


### PR DESCRIPTION
PSKreporter supports a separate field for rig information according to https://pskreporter.info/pskdev.html. We can use attribute 30351.13 rigInformation for this. This adds a separate field in the reporter settings to accomplish this.

PSKreporter would look as follows (openwebrx+ with AirSpy R2 receiver):

<img width="686" height="371" alt="image" src="https://github.com/user-attachments/assets/20b09b72-dd6d-47cd-ba4c-165555c8897b" />
