### PR TITLE
Add "ism_record_levels" option.

### DIFF
--- a/csdr/module/toolbox.py
+++ b/csdr/module/toolbox.py
@@ -10,8 +10,9 @@ class Rtl433Module(ExecModule):
             "-M", "time:unix" if jsonOutput else "time:utc",
             "-F", "json" if jsonOutput else "kv",
             "-A", "-Y", "autolevel",
-            # "-M", "level",
         ]
+        if Config.get()["ism_record_levels"]:
+            cmd += ["-M", "level"]
         super().__init__(Format.COMPLEX_FLOAT, Format.CHAR, cmd)
 
 

--- a/owrx/config/defaults.py
+++ b/owrx/config/defaults.py
@@ -427,6 +427,7 @@ defaultConfig = PropertyLayer(
     image_quantize_colors="256",
     cw_showcw=False,
     dsc_show_errors=True,
+    ism_record_levels=False,
     gps_updates=False,
     bandplan_region=0,
     rig_enabled=False,

--- a/owrx/controllers/settings/decoding.py
+++ b/owrx/controllers/settings/decoding.py
@@ -63,6 +63,10 @@ class DecodingSettingsController(SettingsFormController):
                     "dsc_show_errors",
                     "Show partial messages when decoding DSC",
                 ),
+                CheckboxInput(
+                    "ism_record_levels",
+                    "Record ISM signal levels (RSSI/SNR/Noise)",
+                ),
             ),
             Section(
                 "Digital voice",


### PR DESCRIPTION
**Enabling this option will record RSSI/SNR/Noise values to MQTT.**

I have been running this flag for a few months now -- and figured it would be nice to have upstream. I use the `-M level` flag to measure a bunch of ISM devices in my local area; The MQTT signal strength data has been easy to read into Home Assistant too.

---
<img height="150" alt="01_option" src="https://github.com/user-attachments/assets/b188c339-fe4a-4255-acfa-5734c2565c51" />
<img height="500" alt="02_home_assistant_plot" src="https://github.com/user-attachments/assets/d62ca27c-f852-4ded-af36-26354f557ffa" />
