### PR TITLE
Fix mqtt client initialization order

### DIFF
--- a/owrx/reporting/mqtt.py
+++ b/owrx/reporting/mqtt.py
@@ -19,10 +19,10 @@ class MqttReporter(Reporter):
     def __init__(self):
         pm = Config.get()
         self.topic = self.DEFAULT_TOPIC
-        self.client = self._getClient()
         self.connected = False
         self.watchLock = threading.Lock()
         self.watching = {}
+        self.client = self._getClient()
         self.subscriber = MqttSubscriber(self)
         self.subscriptions = [
             pm.wireProperty("mqtt_topic", self._setTopic),


### PR DESCRIPTION
Since https://github.com/luarvique/openwebrx/commit/afa53fbe19baa65666240fb61b1c0fc67e5390f7 I get the following AttributeError:
```
2025-12-09 22:57:27,187 - owrx.__main__ - INFO - Ready to serve requests.
     self.run()
   File "/usr/lib/python3.11/threading.py", line 975, in run
     self._target(*self._args, **self._kwargs)
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1756, in loop_forever
     rc = self._loop(timeout)
          ^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1164, in _loop
     rc = self.loop_read()
          ^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1556, in loop_read
     rc = self._packet_read()
          ^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 2439, in _packet_read
     rc = self._packet_handle()
          ^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3039, in _packet_handle
     return self._handle_connack()
            ^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3135, in _handle_connack
     on_connect(self, self._userdata,
   File "/usr/lib/python3/dist-packages/owrx/reporting/mqtt.py", line 84, in _onConnect
     with self.watchLock:
          ^^^^^^^^^^^^^^
 AttributeError: 'MqttReporter' object has no attribute 'watchLock'
```

This seems to happen because the `_onConnect` callback is called before `self.watchLock` is initialized.
I fixed this by reordering the initialization of the attributes in the constructor.
