### PR TITLE
Convert FreeDV to RADEV1 support

### DIFF
--- a/csdr/module/freedv.py
+++ b/csdr/module/freedv.py
@@ -7,5 +7,5 @@ class FreeDVModule(ExecModule):
         super().__init__(
             Format.SHORT,
             Format.SHORT,
-            ["freedv_rx", "1600", "-", "-"]
+            ["webrx_rade_decode"]
         )

--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -79,7 +79,7 @@ class FeatureDetector(object):
         "runds": ["runds_connector"],
         # optional features and their requirements
         "digital_voice_digiham": ["digiham", "codecserver_ambe"],
-        "digital_voice_freedv": ["freedv_rx"],
+        "digital_voice_freedv": ["webrx_rade_decode"],
         "digital_voice_m17": ["m17_demod"],
         "wsjt-x": ["wsjtx"],
         "wsjt-x-2-3": ["wsjtx_2_3"],
@@ -585,18 +585,15 @@ class FeatureDetector(object):
         """
         return self.command_is_runnable("rockprog")
 
-    def has_freedv_rx(self):
+    def has_webrx_rade_decode(self):
         """
-        The `freedv_rx` executable is required to demodulate FreeDV digital
-        transmissions. It comes as part of the `codec2` library build, but is
-        not installed by default or contained inside the `codec2` packages.
+        The `webrx_rade_decode` executable is required to demodulate FreeDV digital
+        transmissions.
 
-        To obtain it, you will have to compile 'codec2' from the sources and
-        then manually install `freedv_rx`. The detailed installation
-        instructions are available from the
-        [OpenWebRX Wiki](https://github.com/jketterl/openwebrx/wiki/FreeDV-demodulator-notes).
+        To obtain it, you will have to compile 'radae_decoder' from the [sources](https://github.com/peterbmarks/radae_decoder) and
+        then manually install `tools/webrx_rade_decode`.
         """
-        return self.command_is_runnable("freedv_rx")
+        return self.command_is_runnable("webrx_rade_decode -h")
 
     def has_dream(self):
         """


### PR DESCRIPTION
The old modes are basically removed, they are hidden behind menu options, so RadeV1 is the only mode that sees any use on air.

https://github.com/peterbmarks/radae_decoder made this switch extremely easy, all that is needed is to compile this and install webrx_rade_decode into /usr/local/bin/ to make FreeDV functional again.

I am still not sure how to attack the LSB/USB selection though, so this PR isn't fully complete.