### PR TITLE
sddc: add 128MHz ADC support for RX-888 mkII via SoapySDDC

### DIFF
--- a/owrx/source/sddc_soapy.py
+++ b/owrx/source/sddc_soapy.py
@@ -1,7 +1,8 @@
 from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
-from owrx.form.input import Input, CheckboxInput
+from owrx.form.input import Input, CheckboxInput, NumberInput
 from owrx.form.input.validator import Range
 from typing import List
+
 
 class SddcSoapySource(SoapyConnectorSource):
     def getSoapySettingsMappings(self):
@@ -9,7 +10,8 @@ class SddcSoapySource(SoapyConnectorSource):
         mappings.update(
             {
                 "bias_tee_hf": "UpdBiasT_HF",
-                "bias_tee_vhf": "UpdBiasT_VHF"
+                "bias_tee_vhf": "UpdBiasT_VHF",
+                "adc_frequency": "adc_frequency"
             }
         )
         return mappings
@@ -17,9 +19,10 @@ class SddcSoapySource(SoapyConnectorSource):
     def getDriver(self):
         return "SDDC"
 
+
 class SddcSoapyDeviceDescription(SoapyConnectorDeviceDescription):
     def getName(self):
-        return "BBRF103 / RX666 / RX888 (SDDC) device (via SoapySDR)"
+        return "BBRF103 / RX666 / RX888 / RX888 mkII (SDDC) device (via SoapySDR)"
 
     def getInputs(self) -> List[Input]:
         return super().getInputs() + [
@@ -31,11 +34,16 @@ class SddcSoapyDeviceDescription(SoapyConnectorDeviceDescription):
                 "bias_tee_vhf",
                 "Enable BIAS-T for VHF antenna port"
             ),
+            NumberInput(
+                "adc_frequency",
+                "ADC Frequency (Hz)",
+                infotext="ADC sampling frequency in Hz. Default 128000000 for RX-888 mkII, 64000000 for other devices. Range: 50000000-140000000 (high-ADC), 50000000-64000000 (standard)."
+            ),
         ]
 
     def getDeviceOptionalKeys(self):
         return super().getDeviceOptionalKeys() + [
-            "bias_tee_hf", "bias_tee_vhf"
+            "bias_tee_hf", "bias_tee_vhf", "adc_frequency"
         ]
 
     def getGainStages(self):
@@ -51,4 +59,5 @@ class SddcSoapyDeviceDescription(SoapyConnectorDeviceDescription):
             Range(8000000),
             Range(16000000),
             Range(32000000),
+            Range(64000000),
         ]


### PR DESCRIPTION
- Add adc_frequency setting mapped to SoapySDR 'adc_frequency' key
- Add NumberInput UI for configuring ADC frequency
- Mark adc_frequency as optional device key
- Extend getSampleRateRanges() to include 64MHz (available at 128MHz ADC)
- Update device name to include RX888 mkII

Follows [SoapySDDC commit 331b35c](https://github.com/ik1xpv/ExtIO_sddc/commit/331b35cd619bf4af20444d64dc35b13a474493e6) which introduced dynamic ADC frequency control, allowing RX-888 mkII to operate at 128MHz instead of 64MHz, doubling the usable bandwidth to 64MHz.