### PR TITLE
Update perseussdr.py

### DIFF
--- a/owrx/source/perseussdr.py
+++ b/owrx/source/perseussdr.py
@@ -85,9 +85,5 @@ class PerseussdrDeviceDescription(DirectSourceDeviceDescription):
 
     def getSampleRateRanges(self) -> List[Range]:
         return [
-            Range(125000),
-            Range(250000),
-            Range(500000),
-            Range(1000000),
-            Range(2000000),
+            Range(48000, 2000000),
         ]


### PR DESCRIPTION
Modify the available bandwiths of the Perseus to match the factory definitions 48kHz - 2MHz.