### PR TITLE
Fix dsp.py for use with perseustest and nmux

### DIFF
--- a/owrx/dsp.py
+++ b/owrx/dsp.py
@@ -841,8 +841,15 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
         self.chain.setHighCut(None if highCut is PropertyDeleted else highCut)
 
     def start(self):
+        logger.debug("dsp: start(self) called")
         if self.sdrSource.isAvailable():
-            self.chain.setReader(self.sdrSource.getBuffer().getReader())
+            logger.debug("dsp: self.sdrSource.isAvailable")
+            if self.chain:
+                 logger.debug("self.chain is available")
+                 self.chain.setReader(self.sdrSource.getBuffer().getReader())
+            else:
+                logger.debug("self.chain is NOT available, calling __init__")
+                self.__init__(self.handler, self.sdrSource)
         else:
             self.startOnAvailable = True
 


### PR DESCRIPTION
If during starting or switching of a profile the secondary chain is not available, it is initialized. This should prevent the following error (NIL pointer exception):

AttributeError: 'NoneType' object has no attribute 'setReader' 2026-02-14 17:50:44,563 - owrx.websocket - ERROR - Exception in websocket handler handleTextMessage() Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/owrx/websocket.py", line 230, in read_loop
    self.messageHandler.handleTextMessage(self, message)
  File "/usr/lib/python3/dist-packages/owrx/connection.py", line 329, in handleTextMessage
    dsp.start()
  File "/usr/lib/python3/dist-packages/owrx/dsp.py", line 840, in start
    self.chain.setReader(self.sdrSource.getBuffer().getReader())
    ^^^^^^^^^^^^^^^^^^^^