### PR TITLE
Fix RigControl not tracking frequency on initial page load

### DIFF
--- a/owrx/rigcontrol.py
+++ b/owrx/rigcontrol.py
@@ -317,16 +317,18 @@ class RigControl():
         self.mod     = None
         self.fCenter = None
         self.fOffset = None
+        super().__init__()
+        # Start RigControl before wiring properties: rigStart() clears
+        # fCenter/fOffset, so it must run before wireProperty callbacks
+        # populate them with current values.
+        if self.enabled:
+            self.enabled = self.rigStart()
         self.subscriptions = [
             props.wireProperty("offset_freq", self.setFrequencyOffset),
             props.wireProperty("center_freq", self.setCenterFrequency),
             props.wireProperty("rig_enabled", self.setRigEnabled),
             props.wireProperty("mod", self.setDemodulator),
         ]
-        super().__init__()
-        # Start RigControl if enabled
-        if self.enabled:
-            self.enabled = self.rigStart()
 
     def stop(self):
         for sub in self.subscriptions:


### PR DESCRIPTION
rigStart() unconditionally clears fCenter and fOffset after the rigctl process is started. When wireProperty subscriptions are set up before rigStart(), the immediate callback from wireProperty("center_freq") correctly populates fCenter, but rigStart() then overwrites it with None.

This causes setFrequencyOffset() to silently skip all frequency commands (guarded by `if self.fCenter is not None`) until a profile change re-fires setCenterFrequency and repopulates fCenter.

Fix by moving rigStart() before the wireProperty subscriptions so that the clearing happens first (on already-None values) and the property callbacks then populate fCenter/fOffset with correct values that are never overwritten.