### PR TITLE
independent payload-display

### DIFF
--- a/csdr/chain/toolbox.py
+++ b/csdr/chain/toolbox.py
@@ -229,7 +229,7 @@ class LoraDemodulator(ServiceDemodulator, DialFrequencyReceiver):
 class LoraWanDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "7", "-w", "64",
+            "-H", "5", "-b", "7", "-w", "64",
             "-s", "12", "-s", "11", "-s", "10", "-s", "9", "-s", "8",
             "-s", "7", "-s", "-12", "-s", "-11", "-s", "-10",
             "-s", "-9", "-s", "-8", "-s", "-7"
@@ -239,34 +239,34 @@ class LoraWanDemodulator(LoraDemodulator):
 class LoraAprsDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "7", "-w", "64", "-s", "9", "-s", "12", "-W", "50"
+            "-H", "5", "-b", "7", "-w", "64", "-s", "9", "-s", "12", "-W", "50"
         ])
 
 
 class LoraFanetDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "8", "-w", "128", "-s", "7"
+            "-H", "5", "-b", "8", "-w", "128", "-s", "7"
         ])
 
 
 class MeshtasticDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "8", "-w", "256", "-s", "7", "-s", "8", "-s", "9",
-            "-s", "10", "-s", "11", "-W", "50"
+            "-H", "5", "-b", "8", "-w", "256", "-s", "7", "-s", "8",
+            "-s", "9", "-s", "10", "-s", "11", "-W", "50"
         ])
 
 
 class MeshcoreDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "6", "-w", "256", "-s", "7", "-s", "8", "-W", "50"
+            "-H", "5", "-b", "6", "-w", "256", "-s", "7", "-s", "8", "-W", "50"
         ])
 
 
 class MeshComDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-b", "8", "-w", "256", "-s", "10", "-s", "11", "-W", "50"
+            "-H", "1", "-b", "8", "-w", "256", "-s", "10", "-s", "11", "-W", "50"
         ])

--- a/csdr/chain/toolbox.py
+++ b/csdr/chain/toolbox.py
@@ -229,7 +229,7 @@ class LoraDemodulator(ServiceDemodulator, DialFrequencyReceiver):
 class LoraWanDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "5", "-b", "7", "-w", "64",
+            "-H", "5", "-b", "7",
             "-s", "12", "-s", "11", "-s", "10", "-s", "9", "-s", "8",
             "-s", "7", "-s", "-12", "-s", "-11", "-s", "-10",
             "-s", "-9", "-s", "-8", "-s", "-7"
@@ -239,34 +239,34 @@ class LoraWanDemodulator(LoraDemodulator):
 class LoraAprsDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "5", "-b", "7", "-w", "64", "-s", "9", "-s", "12", "-W", "50"
+            "-H", "5", "-W", "50", "-b", "7", "-s", "9", "-s", "12"
         ])
 
 
 class LoraFanetDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "5", "-b", "8", "-w", "128", "-s", "7"
+            "-H", "5", "-b", "8", "-s", "7"
         ])
 
 
 class MeshtasticDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "5", "-b", "8", "-w", "256", "-s", "7", "-s", "8",
-            "-s", "9", "-s", "10", "-s", "11", "-W", "50"
+            "-H", "5", "-W", "50", "-b", "8", "-s", "7", "-s", "8",
+            "-s", "9", "-s", "10", "-s", "11"
         ])
 
 
 class MeshcoreDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "5", "-b", "6", "-w", "256", "-s", "7", "-s", "8", "-W", "50"
+            "-H", "5", "-W", "50", "-b", "6", "-s", "7", "-s", "8"
         ])
 
 
 class MeshComDemodulator(LoraDemodulator):
     def __init__(self, sampleRate: int = 1000000, service: bool = False):
         super().__init__(sampleRate, [
-            "-H", "1", "-b", "8", "-w", "256", "-s", "10", "-s", "11", "-W", "50"
+            "-H", "1", "-W", "50", "-b", "8", "-s", "10", "-s", "11"
         ])

--- a/csdr/module/toolbox.py
+++ b/csdr/module/toolbox.py
@@ -111,7 +111,7 @@ class LoraModule(PopenModule):
     def __init__(self, sampleRate: int = 1000000, jsonOutput: bool = False, options=[]):
         self.cmd = [
             "lorarx", "-i", "/dev/stdin", "-r", str(sampleRate),
-            "-f", "f32", "-H", "5", "-v", "-N", "-Q"
+            "-f", "f32", "-v", "-N", "-Q"
         ] + options
         if jsonOutput:
             self.cmd += [ "-j", "/dev/stdout" ]

--- a/owrx/dsp.py
+++ b/owrx/dsp.py
@@ -797,8 +797,8 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
             from csdr.chain.toolbox import MeshcoreDemodulator
             return MeshcoreDemodulator()
         elif mod == "meshcom":
-            from csdr.chain.toolbox import MeshcomDemodulator
-            return MeshcomDemodulator()
+            from csdr.chain.toolbox import MeshComDemodulator
+            return MeshComDemodulator()
         elif mod == "sonde-mts01":
             from csdr.chain.sonde import Mts01Demodulator
             return Mts01Demodulator()


### PR DESCRIPTION
decoder-independent use of lorarx's -H parameter, to prevent false MeshCom parsing