### PR TITLE
Remove CHU beacon

### DIFF
--- a/bookmarks.d/misc.json
+++ b/bookmarks.d/misc.json
@@ -55,11 +55,6 @@
         "modulation" : "usb"
     },
     {
-        "name" : "Time - CHU",
-        "frequency" : 3330000,
-        "modulation" : "usb"
-    },
-    {
         "name" : "Time - RWM",
         "frequency" : 4996000,
         "modulation" : "cw"
@@ -75,11 +70,6 @@
         "modulation" : "usb"
     },
     {
-        "name" : "Time - CHU",
-        "frequency" : 7850000,
-        "modulation" : "usb"
-    },
-    {
         "name" : "Time - RWM",
         "frequency" : 9996000,
         "modulation" : "cw"
@@ -92,11 +82,6 @@
     {
         "name" : "Time - PLC",
         "frequency" : 11440000,
-        "modulation" : "usb"
-    },
-    {
-        "name" : "Time - CHU",
-        "frequency" : 14670000,
         "modulation" : "usb"
     },
     {


### PR DESCRIPTION
CHU beacon was shut down 22nd June 2026:
- https://nrc.canada.ca/en/certifications-evaluations-standards/canadas-official-time/nrc-shortwave-station-broadcasts-chu
- https://www.radioworld.com/news-and-business/headlines/canadas-chu-shortwave-time-station-to-be-silenced