### PR TITLE
Fix two small DSP reliability bugs found on a live station

### DIFF
--- a/owrx/aprs/direwolf.py
+++ b/owrx/aprs/direwolf.py
@@ -172,6 +172,9 @@ class DirewolfModule(AutoStartModule, DirewolfConfigSubscriber):
         return Format.CHAR
 
     def start(self):
+        # avoid a duplicate spawn if _checkStart() fires again while already running
+        if self.process is not None:
+            return
         self.direwolfConfig = DirewolfConfig()
         self.direwolfConfig.wire(self)
         file = open(self.direwolfConfigPath, "w")

--- a/owrx/dsp.py
+++ b/owrx/dsp.py
@@ -521,8 +521,6 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
             mode = Modes.findByModulation(self.props["start_mod"])
             if mode:
                 self.setDemodulator(mode.get_modulation())
-                if isinstance(mode, DigitalMode):
-                    self.setSecondaryDemodulator(mode.modulation)
                 if mode.bandpass:
                     bpf = [mode.bandpass.low_cut, mode.bandpass.high_cut]
                     self.chain.setBandpass(*bpf)
@@ -563,6 +561,15 @@ class DspManager(SdrSourceEventClient, ClientDemodulatorSecondaryDspEventClient)
             self.props.wireProperty("nr_enabled", self.chain.setNrEnabled),
             self.props.wireProperty("nr_threshold", self.chain.setNrThreshold),
         ]
+
+        # applying this via self.props (now that "secondary_mod" is wired above)
+        # instead of a raw setSecondaryDemodulator() call means a later dspcontrol
+        # message resending the same start_mod-derived value is a no-op instead of
+        # spawning a second, orphaned secondary demodulator (e.g. direwolf for AIS)
+        if "start_mod" in self.props:
+            startMode = Modes.findByModulation(self.props["start_mod"])
+            if isinstance(startMode, DigitalMode):
+                self.props["secondary_mod"] = startMode.modulation
 
         # wire power level output
         buffer = Buffer(Format.FLOAT)


### PR DESCRIPTION
Found these while debugging an unrelated AIS decode issue on a live station
(https://w1ors.asuscomm.com) - a duplicate direwolf instance was a real,
if minor, side effect uncovered along the way. Two independent, small fixes:

1. **DirewolfModule.start() had no re-entrancy guard.** AutoStartModule's
   `_checkStart()` calls `start()` from both `setReader()` and `setWriter()` -
   in normal usage that's two calls, and a subclass with no guard of its
   own gets `start()` run twice, spawning a duplicate direwolf process.
   `ThreadModule` already guards this same scenario (`if self.is_alive():
   return`); `DirewolfModule` (which extends `AutoStartModule` directly, not
   `ThreadModule`) had none.

2. **start_mod-implied secondary_mod bypassed the property dedup.** When
   a profile's `start_mod` resolves to a `DigitalMode`, `DspManager` called
   `setSecondaryDemodulator()` directly instead of going through
   `self.props["secondary_mod"] = ...` - skipping the property layer's own
   no-op-if-unchanged check. A client resending the same start_mod-derived
   value later (which happens in normal use) isn't recognized as a no-op,
   and can spawn a second, orphaned secondary demodulator alongside the
   first. Moved the assignment after the property watchers are wired, so
   it goes through the same dedup path a normal dspcontrol message would.

Both verified against a live station (dsp.py/direwolf.py patched directly,
confirmed no more duplicate spawns before writing this up as a proper PR).