### PR TITLE
Fix HD Radio images leaking across programs

### DIFF
--- a/csdr/module/hdradio.py
+++ b/csdr/module/hdradio.py
@@ -1,4 +1,4 @@
-from csdr.module.nrsc5 import NRSC5, Mode, EventType, ComponentType, Access
+from csdr.module.nrsc5 import NRSC5, Mode, EventType, ComponentType, Access, ServiceType, MIMEType
 from csdr.module import ThreadModule
 from pycsdr.modules import Writer
 from pycsdr.types import Format
@@ -36,6 +36,9 @@ class HdRadioModule(ThreadModule):
         self.metaLock   = threading.Lock()
         self.metaWriter = None
         self.meta       = {}
+        # Station logo received for each HD audio service.
+        # Service numbers are 1-based: HD1=1, HD2=2, ...
+        self.programLogos = {}
         self._clearMeta()
         # Initialize and start NRSC5 decoder
         self.radio = NRSC5(lambda evt_type, evt: self.callback(evt_type, evt))
@@ -79,11 +82,21 @@ class HdRadioModule(ThreadModule):
                     del self.meta["genre"]
                 self._writeMeta()
 
+            # Restore the station logo for this HD program.
+            image = self.programLogos.get(self.program + 1)
+            if image is not None:
+                logger.info(
+                    "Restoring cached station logo for P%d: lot=%s name=%s",
+                    self.program + 1, image[0], image[1]
+                )
+                self._writeImage(*image)
+
     # Change frequency
     def setFrequency(self, frequency: int) -> None:
         if frequency != self.frequency:
             self.frequency = frequency
             self.program = 0
+            self.programLogos.clear()
             logger.info("Now playing program #{0} at {1}MHz".format(self.program, self.frequency / 1000000))
             self._clearMeta()
 
@@ -222,7 +235,25 @@ class HdRadioModule(ThreadModule):
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
             logger.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
                          evt.port, evt.lot, evt.name, len(evt.data), evt.mime, time_str)
-            self._writeImage(evt.lot, evt.name, evt.data)
+            if evt.service is not None and evt.service.type == ServiceType.AUDIO:
+                # Cache station logos, but not potentially transient images.
+                if (evt.component is not None
+                        and evt.component.data is not None
+                        and evt.component.data.mime == MIMEType.STATION_LOGO):
+                    self.programLogos[evt.service.number] = (
+                        evt.lot, evt.name, evt.data
+                    )
+                    logger.info(
+                        "Caching station logo for HD%d: port=%04X lot=%s name=%s",
+                        evt.service.number, evt.port, evt.lot, evt.name
+                    )
+
+                # Display LOT data only for the selected HD program.
+                if evt.service.number == self.program + 1:
+                    self._writeImage(evt.lot, evt.name, evt.data)
+            else:
+                # Preserve previous behaviour for non-audio/unknown services.
+                self._writeImage(evt.lot, evt.name, evt.data)
         elif evt_type == EventType.SIS:
             # Collect new metadata
             meta = {

--- a/htdocs/lib/MetaPanel.js
+++ b/htdocs/lib/MetaPanel.js
@@ -561,6 +561,7 @@ function HdrMetaPanel(el) {
     MetaPanel.call(this, el);
     this.modes = ['HDR'];
     this.frequency = -1;
+    this.program = -1;
 
     // Create info panel
     var $container = $(
@@ -596,18 +597,24 @@ HdrMetaPanel.prototype = new MetaPanel();
 HdrMetaPanel.prototype.update = function(data) {
     if (!this.isSupported(data)) return;
 
+    // Clear logo image when frequency or HD program changes.
+    var frequencyChanged =
+        'frequency' in data && data.frequency != this.frequency;
+    var programChanged =
+        'program' in data && data.program != this.program;
+
+    if (frequencyChanged || programChanged) {
+        if ('frequency' in data) this.frequency = data.frequency;
+        if ('program' in data) this.program = data.program;
+        $('#hdr-logo').html('');
+    }
+
     // If there is an image, display it and do not parse further
     if ('image' in data && 'data' in data) {
         $('#hdr-logo').html(
             '<img src="data:image/png;base64,' + data.data + '">'
         );
         return;
-    }
-
-    // Clear logo image when frequency changes
-    if (data.frequency != this.frequency) {
-        this.frequency = data.frequency;
-        $('#hdr-logo').html('');
     }
 
     // Convert FCC ID to hexadecimal


### PR DESCRIPTION
HD Radio LOT images were displayed without checking which audio service
they belong to. On stations carrying multiple HD programs, this could
cause an image or station logo from another program to replace the image
of the currently selected program.

For example, while listening to HD1, a station logo received for HD2
could replace the HD1 logo even though the selected audio program had
not changed.

This change:

- Associates LOT images from audio services with their originating HD program.
- Displays audio-service LOT images only when they belong to the currently selected program.
- Caches station logos separately for each HD program.
- Restores the cached station logo immediately when switching programs.
- Clears the station-logo cache when changing RF frequency.
- Clears the currently displayed HDR image in the web UI when the selected HD program changes.
- Does not cache potentially transient LOT images such as `PRIMARY_IMAGE`.

Tested with several live HD Radio multiplexes.

One test multiplex carried four audio programs (HD1-HD4), each with a
separate `STATION_LOGO` LOT service. The correct logo was successfully
cached and restored when switching between P1, P2, P3 and P4.

The original issue was also reproduced on a two-program multiplex, where
the HD2 logo incorrectly replaced the HD1 logo while HD1 remained selected.