### PR TITLE
Add SoapyFile to features to allow reading of files

### DIFF
--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -491,6 +491,15 @@ class FeatureDetector(object):
         """
         return self._has_soapy_driver("bladerf")
 
+    def has_soapy_file(self):
+        """
+        The [SoapyFile](https://github.com/utn-ba-rf-lab/SoapyFile)
+        module allows to use both normal and pipe (FIFO) files instead
+        of an antenna. Reading IQ data in CF32 format.
+        To install it, please build it using the instructions in the repo.
+        """
+        return self._has_soapy_driver("file")
+
     def has_m17_demod(self):
         """
         OpenWebRX uses the [M17 Demodulator](https://github.com/mobilinkd/m17-cxx-demod)

--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -75,6 +75,7 @@ class FeatureDetector(object):
         "radioberry": ["soapy_connector", "soapy_radioberry"],
         "fcdpp": ["soapy_connector", "soapy_fcdpp"],
         "bladerf": ["soapy_connector", "soapy_bladerf"],
+        "file": ["soapy_connector", "soapy_file"],
         "sddc": ["sddc_connector"],
         "sddc_soapy": ["soapy_connector", "soapy_sddc"],
         "hpsdr": ["hpsdr_connector"],

--- a/owrx/source/file.py
+++ b/owrx/source/file.py
@@ -1,0 +1,14 @@
+from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
+from owrx.form.input.validator import Range
+from typing import List
+
+class FileSource(SoapyConnectorSource): 
+    def getDriver(self):
+        return "file"
+
+class FileDeviceDescription(SoapyConnectorDeviceDescription):
+    def getName(self):
+        return "IQ File / FIFO source (SoapyFile)"
+
+    def getSampleRateRanges(self) -> List[Range]:
+        return [Range(525000, 1775000)]


### PR DESCRIPTION
Hello, I'm sending this about 3 months after I said I would, sorry.

The idea of this pull request is to add support for the Soapy driver [SoapyFile](https://github.com/utn-ba-rf-lab/SoapyFile), which just allows the playback of CF32 audio files, or audio pipes. Mainly so that, if there's more than one audio sink (for example, I'm managing a server with both OpenWebRX and another SDR web server), a GNURadio ad-hoc could split the source in two or more, and allow multiple receptors to play the signal coming from a SDR device (or allow the usage of an uncommon SDR device through GNU Radio).

The changes just affect two files concretly, a new owrx/source/file.py which implements both SoapyConnectorSource and SoapyConnectorDeviceDescription functions for basic description, and owrx/feature.py, to check for availability and provide a basic description.

It has been tested to work using a simple sine creator from GNU Radio writing to a pipe file.

Thanks for the attention.